### PR TITLE
Tidied up .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,11 @@
+# Android Studio files
 *.iml
 .idea
 .gradle
 local.properties
-.idea/caches
-.idea/libraries
-.idea/modules.xml
-.idea/workspace.xml
+
 .DS_Store
+
 /build
 /captures
 .externalNativeBuild
-catedroid-release-key.jks
-keystore.properties


### PR DESCRIPTION
Just a quick tidy up of the `.gitignore` file.

- Removed entries for files inside `.idea` folder as they are covered by the `.idea` entry anyway
- Removed old release key and `keystore.properties` file as they are no longer needed under the new build process